### PR TITLE
fix: add @send to getEntries

### DIFF
--- a/src/Contentful.res
+++ b/src/Contentful.res
@@ -210,8 +210,8 @@ external createClient: clientOpts<'adapter, 'headers, 'httpAgent, 'httpsAgent, '
 @send
 external getContentTypes: (t, ~query: 'query=?, unit) => Js.Promise.t<contentTypeCollection> =
   "getContentTypes"
-@send
 @send external getEntry: (t, string) => Js.Promise.t<option<entry<'fields>>> = "getEntry"
+@send
 external getEntries: (t, ~query: 'query=?, unit) => Js.Promise.t<entryCollection<'fields>> =
   "getEntries"
 @send external getSpace: t => Js.Promise.t<space> = "getSpace"
@@ -220,4 +220,3 @@ external getEntries: (t, ~query: 'query=?, unit) => Js.Promise.t<entryCollection
 @send external getTags: (t, ~query: 'query=?, unit) => Js.Promise.t<tagCollection> = "getTags"
 @send external parseEntries: (t, 'raw) => Js.Promise.t<entryCollection<'fields>> = "parseEntries"
 @send external sync: (t, 'query) => Js.Promise.t<syncCollection> = "sync"
-


### PR DESCRIPTION
Currently there are no `@send` directive in the `getEntries` function. Which produces the "Unimplemented primitive used" warning: 

![image](https://user-images.githubusercontent.com/46231311/150177891-f8278680-8766-469d-b228-53285437b46b.png)

Also,  there is two `@send` directives in `getEntry`. This PR fixes this. 
